### PR TITLE
Add bootstrap and basic front end libs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 # app specific
 secrets.json
 
+# compiled js css
+wwwroot/js/
+wwwroot/css/
+
 # Logs
 logs
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,8 @@
 secrets.json
 
 # compiled js css
-wwwroot/js/
-wwwroot/css/
+*.min.js
+*.min.css
 
 # Logs
 logs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,15 @@ steps:
 - script: dotnet build $(Build.SourcesDirectory)/time-tracker-webapi/ --configuration $(buildConfiguration)
   displayName: 'dotnet build $(buildConfiguration)'
 
+- task: Npm@1
+  displayName: 'npm install on package.json for frontend libs'
+  inputs:
+    command: 'install'
+    workingDir: '$(Build.SourcesDirectory)/time-tracker-webapi/src/TimeTracker.Api/'
+
+- script: dotnet bundle $(Build.SourcesDirectory)/time-tracker-webapi/src/TimeTracker.Api/ --configuration $(buildConfiguration)
+  displayName: 'bundle css and js'
+
 - script: |
     mkdir $(Build.SourcesDirectory)/results
     dotnet test --logger trx /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura  $(Build.SourcesDirectory)/time-tracker-webapi/test/TimeTracker.Api.Test/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,16 +14,18 @@ variables:
   Authentication__Google__ClientId: '1234'
 
 steps:
-- script: dotnet build $(Build.SourcesDirectory)/time-tracker-webapi/ --configuration $(buildConfiguration)
-  displayName: 'dotnet build $(buildConfiguration)'
-
 - task: Npm@1
   displayName: 'npm install on package.json for frontend libs'
   inputs:
     command: 'install'
     workingDir: '$(Build.SourcesDirectory)/time-tracker-webapi/src/TimeTracker.Api/'
 
-- script: dotnet bundle $(Build.SourcesDirectory)/time-tracker-webapi/src/TimeTracker.Api/ --configuration $(buildConfiguration)
+- script: dotnet build $(Build.SourcesDirectory)/time-tracker-webapi/ --configuration $(buildConfiguration)
+  displayName: 'dotnet build $(buildConfiguration)'
+
+- script: |
+    cd $(Build.SourcesDirectory)/time-tracker-webapi/src/TimeTracker.Api/
+    dotnet bundle
   displayName: 'bundle css and js'
 
 - script: |

--- a/time-tracker-webapi/src/TimeTracker.Api/Properties/launchSettings.json
+++ b/time-tracker-webapi/src/TimeTracker.Api/Properties/launchSettings.json
@@ -20,7 +20,7 @@
     "TimeTracker.Api": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "api/values",
+      "launchUrl": "/",
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/time-tracker-webapi/src/TimeTracker.Api/Startup.cs
+++ b/time-tracker-webapi/src/TimeTracker.Api/Startup.cs
@@ -47,6 +47,8 @@ namespace TimeTracker.Api
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
+            app.UseStaticFiles(); // support wwwroot
+            
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();

--- a/time-tracker-webapi/src/TimeTracker.Api/Startup.cs
+++ b/time-tracker-webapi/src/TimeTracker.Api/Startup.cs
@@ -1,10 +1,13 @@
-﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
+﻿using System.IO;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.FileProviders;
 using TimeTracker.Data;
 
 namespace TimeTracker.Api
@@ -52,6 +55,13 @@ namespace TimeTracker.Api
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
+                // add support to load node_modules libraries in dev mode
+                app.UseStaticFiles(new StaticFileOptions()
+                {
+                    FileProvider = new PhysicalFileProvider(
+                        Path.Combine(Directory.GetCurrentDirectory(), @"node_modules")),
+                    RequestPath = new PathString("/node_modules")
+                });
             }
             else
             {
@@ -60,7 +70,7 @@ namespace TimeTracker.Api
                 
                 app.UseAuthentication();
             }
-
+            
             // global cors policy
             app.UseCors(x => x
                 .AllowAnyOrigin()

--- a/time-tracker-webapi/src/TimeTracker.Api/Startup.cs
+++ b/time-tracker-webapi/src/TimeTracker.Api/Startup.cs
@@ -63,7 +63,7 @@ namespace TimeTracker.Api
                     RequestPath = new PathString("/node_modules")
                 });
             }
-            else
+            else if(!env.IsEnvironment("Test"))
             {
                 app.UseHsts();
                 app.UseHttpsRedirection();

--- a/time-tracker-webapi/src/TimeTracker.Api/TimeTracker.Api.csproj
+++ b/time-tracker-webapi/src/TimeTracker.Api/TimeTracker.Api.csproj
@@ -35,23 +35,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <DotNetCliToolReference Include="BundlerMinifier.Core" Version="2.6.362" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Remove="Infrastructure\**" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <EmbeddedResource Remove="Infrastructure\**" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Remove="Infrastructure\**" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Remove="Infrastructure\**" />
+    <DotNetCliToolReference Include="BundlerMinifier.Core" Version="2.9.406" />
   </ItemGroup>
 
 </Project>

--- a/time-tracker-webapi/src/TimeTracker.Api/TimeTracker.Api.csproj
+++ b/time-tracker-webapi/src/TimeTracker.Api/TimeTracker.Api.csproj
@@ -21,6 +21,8 @@
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="2.2.0" />
+    
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />

--- a/time-tracker-webapi/src/TimeTracker.Api/TimeTracker.Api.csproj
+++ b/time-tracker-webapi/src/TimeTracker.Api/TimeTracker.Api.csproj
@@ -31,6 +31,10 @@
     <ProjectReference Include="..\TimeTracker.Data\TimeTracker.Data.csproj" />
     <ProjectReference Include="..\TimeTracker.Library\TimeTracker.Library.csproj" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <DotNetCliToolReference Include="BundlerMinifier.Core" Version="2.6.362" />
+  </ItemGroup>
 
   <ItemGroup>
     <Compile Remove="Infrastructure\**" />

--- a/time-tracker-webapi/src/TimeTracker.Api/TimeTracker.Api.csproj
+++ b/time-tracker-webapi/src/TimeTracker.Api/TimeTracker.Api.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
     
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.0" />

--- a/time-tracker-webapi/src/TimeTracker.Api/Views/Shared/_Layout.cshtml
+++ b/time-tracker-webapi/src/TimeTracker.Api/Views/Shared/_Layout.cshtml
@@ -7,18 +7,43 @@
 <html>
 <head>
     <title>@ViewBag.Title</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="description" content="">
+    <link href="/css/bootstrap.min.css" rel="stylesheet"/>
+    <script defer src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+    <script defer src="/js/bootstrap.min.js"></script>
 </head>
 <body>
-<div>
-    <a href=@Url.Action(action: "AllUsersReport", controller: "AdminReports")>YTD Report</a>
-    <a href="">Pay Period Report</a>
-</div>
-<div class="container body-content">
-    @RenderBody()
-    <hr/>
-    <footer>
-        <p>&copy; 2019</p>
-    </footer>
-</div>
+<nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">
+    <a class="navbar-brand" href="#">Navbar</a>
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+    </button>
+
+    <div class="collapse navbar-collapse" id="navbarsExampleDefault">
+        <ul class="navbar-nav mr-auto">
+            <li class="nav-item active">
+                <a class="nav-link" href=@Url.Action(action: "AllUsersReport", controller: "AdminReports")>Reports</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link" href="#">Link</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link disabled" href="#">Disabled</a>
+            </li>
+        </ul>
+        <form class="form-inline my-2 my-lg-0">
+            <input class="form-control mr-sm-2" type="text" placeholder="Search" aria-label="Search">
+            <button class="btn btn-outline-success my-2 my-sm-0" type="submit">Search</button>
+        </form>
+    </div>
+</nav>
+<main role="main" class="container" style="margin-top: 70px;">
+    <div class="container body-content">
+        @RenderBody()
+        <hr/>
+    </div>
+</main>
 </body>
 </html>

--- a/time-tracker-webapi/src/TimeTracker.Api/Views/Shared/_Layout.cshtml
+++ b/time-tracker-webapi/src/TimeTracker.Api/Views/Shared/_Layout.cshtml
@@ -10,9 +10,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="description" content="">
-    <link href="/css/bootstrap.min.css" rel="stylesheet"/>
-    <script defer src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
-    <script defer src="/js/bootstrap.min.js"></script>
+    <environment include="Development">
+        <link href="/node_modules/bootstrap/dist/css/bootstrap.css" rel="stylesheet"/>
+        <script defer src="/node_modules/jquery/dist/jquery.slim.js"></script>
+        <script defer src="/node_modules/bootstrap/dist/js/bootstrap.js"></script>
+    </environment>
+    <environment exclude="Development">
+        <link href="/css/bootstrap.min.css" rel="stylesheet"/>
+        <script defer src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+        <script defer src="/js/bootstrap.min.js"></script>
+    </environment>
 </head>
 <body>
 <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">
@@ -41,6 +48,12 @@
 </nav>
 <main role="main" class="container" style="margin-top: 70px;">
     <div class="container body-content">
+        <environment include="Development">
+            <strong> Development env ON</strong>
+        </environment>
+        <environment exclude="Development">
+            <strong> Development env OFF</strong>
+        </environment>
         @RenderBody()
         <hr/>
     </div>

--- a/time-tracker-webapi/src/TimeTracker.Api/Views/Shared/_Layout.cshtml
+++ b/time-tracker-webapi/src/TimeTracker.Api/Views/Shared/_Layout.cshtml
@@ -48,12 +48,6 @@
 </nav>
 <main role="main" class="container" style="margin-top: 70px;">
     <div class="container body-content">
-        <environment include="Development">
-            <strong> Development env ON</strong>
-        </environment>
-        <environment exclude="Development">
-            <strong> Development env OFF</strong>
-        </environment>
         @RenderBody()
         <hr/>
     </div>

--- a/time-tracker-webapi/src/TimeTracker.Api/Views/Shared/_Layout.cshtml
+++ b/time-tracker-webapi/src/TimeTracker.Api/Views/Shared/_Layout.cshtml
@@ -16,9 +16,10 @@
         <script defer src="/node_modules/bootstrap/dist/js/bootstrap.js"></script>
     </environment>
     <environment exclude="Development">
-        <link href="/css/bootstrap.min.css" rel="stylesheet"/>
-        <script defer src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
-        <script defer src="/js/bootstrap.min.js"></script>
+        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+        <script defer src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+        <script defer src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
+        <script defer src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
     </environment>
 </head>
 <body>

--- a/time-tracker-webapi/src/TimeTracker.Api/Views/_ViewImports.cshtml
+++ b/time-tracker-webapi/src/TimeTracker.Api/Views/_ViewImports.cshtml
@@ -1,0 +1,1 @@
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/time-tracker-webapi/src/TimeTracker.Api/Views/_ViewImports.cshtml.cs
+++ b/time-tracker-webapi/src/TimeTracker.Api/Views/_ViewImports.cshtml.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TimeTracker.Api.Views
+{
+    public class _ViewImports : PageModel
+    {
+        public void OnGet()
+        {
+            
+        }
+    }
+}

--- a/time-tracker-webapi/src/TimeTracker.Api/bundleconfig.json
+++ b/time-tracker-webapi/src/TimeTracker.Api/bundleconfig.json
@@ -1,0 +1,22 @@
+[
+  {
+    "outputFileName": "wwwroot/js/bootstrap.min.js",
+    "inputFiles": [
+      "node_modules/bootstrap/dist/js/bootstrap.min.js"
+    ],
+    "minify": {
+      "enabled": false,
+      "renameLocals": false
+    },
+    "sourceMap": false
+  },
+  {
+    "outputFileName": "wwwroot/css/bootstrap.min.css",
+    "inputFiles": [
+      "node_modules/bootstrap/dist/css/bootstrap.min.css"
+    ],
+    "minify": {
+      "enabled": false
+    }
+  }
+]

--- a/time-tracker-webapi/src/TimeTracker.Api/package-lock.json
+++ b/time-tracker-webapi/src/TimeTracker.Api/package-lock.json
@@ -1,0 +1,36 @@
+{
+  "name": "IntegralTimeTracker",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "bootstrap": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.0.0.tgz",
+      "integrity": "sha512-gulJE5dGFo6Q61V/whS6VM4WIyrlydXfCgkE+Gxe5hjrJ8rXLLZlALq7zq2RPhOc45PSwQpJkrTnc2KgD6cvmA=="
+    },
+    "font-awesome": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
+      "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
+    },
+    "jquery": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
+      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
+    },
+    "jquery-mask-plugin": {
+      "version": "1.14.13",
+      "resolved": "https://registry.npmjs.org/jquery-mask-plugin/-/jquery-mask-plugin-1.14.13.tgz",
+      "integrity": "sha512-x0+t9+JAcG5V4kbdvEZ6/C2UcNsSLwOcY1CYSwvYAiim2D/EP2qeuxqov4Z3iru3ngUy4ojJCyUb/X/rKo23Tg=="
+    },
+    "jquery-validation": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/jquery-validation/-/jquery-validation-1.17.0.tgz",
+      "integrity": "sha512-XddiAwhGdWhcIJ+W3ri3KG8uTPMua4TPYuUIC8/E7lOyqdScG5xHuy9YishlKc0c/lIQai77EX7hxMdTSYCEjA==",
+      "requires": {
+        "jquery": "^1.7 || ^2.0 || ^3.1"
+      }
+    }
+  }
+}

--- a/time-tracker-webapi/src/TimeTracker.Api/package.json
+++ b/time-tracker-webapi/src/TimeTracker.Api/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "integraltimetracker",
+  "version": "1.0.0",
+  "dependencies": {
+    "jquery": "3.3.1",
+    "jquery-validation": "1.17.0",
+    "jquery-mask-plugin": "1.14.13",
+    "bootstrap": "v4.0.0",
+    "font-awesome": "4.7.0"
+  }
+}

--- a/time-tracker-webapi/test/TimeTracker.Api.Test/HttpClientWithInMemoryDatabase.cs
+++ b/time-tracker-webapi/test/TimeTracker.Api.Test/HttpClientWithInMemoryDatabase.cs
@@ -22,6 +22,7 @@ namespace TimeTracker.Api.Test
 
         private void ConfigureWebHost(IWebHostBuilder builder)
         {
+            builder.UseSetting("Environment", "Test");
             builder.ConfigureServices(async services =>
             {
                 services.AddEntityFrameworkInMemoryDatabase();

--- a/time-tracker-webapi/test/TimeTracker.Api.Test/TimeTracker.Api.Test.csproj
+++ b/time-tracker-webapi/test/TimeTracker.Api.Test/TimeTracker.Api.Test.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.2.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />


### PR DESCRIPTION
Completes Story: [https://integralsoftwareinc.visualstudio.com/IntegralTimeTracker/_workitems/edit/33](33)

Uses NPM to handle frontend libs, so just do `npm install` if developing locally to get libraries. In dev mode will reference full files, and in production mode will reference minified files.
Build pipeline has been modified to do npm install and dotnet bundle to bundle the files