### PR TITLE
Use a real date for ordering the items so they are correctly ordered

### DIFF
--- a/src/TimeTracker.Library/Models/WebReport/UserEntry.cs
+++ b/src/TimeTracker.Library/Models/WebReport/UserEntry.cs
@@ -2,9 +2,13 @@ using System;
 
 namespace TimeTracker.Library.Models.WebReport
 {
+    /// <summary>
+    /// presentation object for the user's web report
+    /// </summary>
     public class UserEntry
     {
         public Guid UserId { get; set; }
+        public DateTime DateForOrdering { get; set; }
         
         public string Name { get; set; }
         public string Date { get; set; }

--- a/src/TimeTracker.Library/Services/WebReportService.cs
+++ b/src/TimeTracker.Library/Services/WebReportService.cs
@@ -35,6 +35,7 @@ namespace TimeTracker.Library.Services
                     UserId = g.FirstOrDefault().UserId,
                     Name = name,
                     Date = g.FirstOrDefault().Date.ToShortDateString(),
+                    DateForOrdering = g.FirstOrDefault().Date,
                     DayOfWeek = g.FirstOrDefault().Date.DayOfWeek.ToString(),
                     BillableHours = g.Where(x=>x.TimeEntryType == TimeEntryTypeEnum.BillableProject).Sum(x=>x.Hours),
                     BillableProject = db.Projects.FirstOrDefault(x => x.ProjectId == (g.FirstOrDefault(y=>y.TimeEntryType == TimeEntryTypeEnum.BillableProject).ProjectId ?? 0))?.Name ?? "",
@@ -45,7 +46,7 @@ namespace TimeTracker.Library.Services
                     OtherNonBillable = g.Where(x=>x.TimeEntryType == TimeEntryTypeEnum.NonBillable).Sum(x=>x.Hours),
                     NonBillableReason = g.FirstOrDefault(x=>x.TimeEntryType == TimeEntryTypeEnum.NonBillable)?.NonBillableReason ?? "" 
                 };
-            return query.OrderByDescending(x => x.Date).ToImmutableList();
+            return query.OrderByDescending(x => x.DateForOrdering).ToImmutableList();
         }
     }
 }

--- a/test/TimeTracker.Library.Test/Services/WebReportServiceTest.cs
+++ b/test/TimeTracker.Library.Test/Services/WebReportServiceTest.cs
@@ -82,7 +82,7 @@ namespace TimeTracker.Library.Test.Services
         public async Task GetUserReport_listsEntriesInDescOrder()
         {
             var report = await webReportService.GetUserReport(userId);
-            var expectedOrderReport = report.OrderByDescending(x => x.Date);
+            var expectedOrderReport = report.OrderByDescending(x => x.DateForOrdering);
             Assert.True(expectedOrderReport.SequenceEqual(report));
         }
 


### PR DESCRIPTION
one adjustmnet could make here would be to only use the date and then apply formatting on the View html side, but this should be good to fix the problem we found